### PR TITLE
Add Redis and Hubot services to Docker Compose configuration

### DIFF
--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -38,7 +38,7 @@ jobs:
         run: docker compose config
 
       - name: Start stack
-        run: docker compose up -d
+        run: docker compose up -d loki alloy grafana
 
       - name: Wait for services to become healthy
         shell: bash

--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ The stack provisions:
 - Grafana for dashboards and alerting
 - Loki for log storage and querying
 - Grafana Alloy for Docker log discovery, relabeling, and forwarding
+- Redis for Hubot brain persistence and short-lived caching
+- Hubot colocated with Loki for Discord bot access to logs
 
 Logs are collected from the Docker socket, labeled with Compose metadata, shipped to Loki, and surfaced in prebuilt Grafana dashboards and alert rules for the Florida Mesh MQTT environment.
 
 ## What This Repository Contains
 
 - `docker-compose.yml`: local stack definition for Loki, Alloy, and Grafana
+- Redis and Hubot services colocated with the observability stack
 - `alloy/config.alloy`: Docker log discovery, relabeling, parsing, and forwarding rules
 - `loki/config.yaml`: single-node Loki configuration backed by a local volume
 - `grafana/provisioning/datasources/loki.yaml`: provisioned Loki datasource
@@ -43,6 +46,8 @@ The included dashboards and alert rules are tuned around that environment, espec
 - MQTT broker authentication and authorization failures
 - unexpected denials on Florida topic paths under `msh/US/FL/#`
 - Floodgate service availability, stats emissions, and error lines
+
+Hubot is colocated with Loki so the bot can query the same log store without depending on the EMQX deployment host.
 
 ## Provisioned Content
 
@@ -80,12 +85,31 @@ GF_SECURITY_ADMIN_USER=admin
 GF_SECURITY_ADMIN_PASSWORD=change-this-now
 ```
 
+To run Hubot successfully, `.env` also needs:
+
+```env
+HUBOT_DISCORD_TOKEN=your-discord-bot-token
+HUBOT_NAME=MeshBot
+HUBOT_LOG_LEVEL=info
+REDIS_URL=redis://redis:6379
+LOKI_URL=http://loki:3100
+LOKI_USERNAME=
+LOKI_PASSWORD=
+NODE_LOGS_CACHE_TTL_SECONDS=30
+```
+
 ## Getting Started
 
 Use the test environment values:
 
 ```bash
 ln -sf .env.test .env
+docker compose up -d loki alloy grafana
+```
+
+To start the full deployed stack, including Redis and Hubot:
+
+```bash
 docker compose up -d
 ```
 
@@ -105,13 +129,16 @@ docker compose down -v
 
 ## Healthchecks
 
-The Compose stack includes healthchecks for all three services:
+The observability services include healthchecks for:
 
 - Loki validates its config with the Loki binary
 - Alloy checks its readiness endpoint on port `12345`
 - Grafana checks `/api/health` on port `3000`
 
 Compose also waits for Loki to become healthy before starting Alloy and Grafana.
+
+- Redis is health-checked with `redis-cli ping`
+- Hubot waits for both Loki and Redis before starting
 
 ## Log Labeling and Parsing
 
@@ -135,10 +162,12 @@ The Alloy config deliberately keeps labels low-cardinality and leaves most struc
 The GitHub Actions workflow in `.github/workflows/compose-validate.yml` validates that:
 
 - the Compose file renders successfully
-- the stack starts successfully
-- all services report healthy
+- the observability services start successfully
+- Loki, Alloy, and Grafana report healthy
 - Grafana provisions the dashboards defined in `grafana/dashboards/`
 - provisioned dashboards can be retrieved through the Grafana HTTP API
+
+The workflow intentionally does not start Hubot because a real `HUBOT_DISCORD_TOKEN` is not available in CI for this repository.
 
 ## Repository Layout
 
@@ -161,4 +190,5 @@ The GitHub Actions workflow in `.github/workflows/compose-validate.yml` validate
 
 - Grafana state is stored in the `grafana-data` volume.
 - Loki data is stored in the `loki-data` volume.
+- Redis brain/cache state is stored in the `redis-data` volume.
 - This repository is focused on observability infrastructure and provisioned assets for Florida Mesh; it does not include the EMQX or Floodgate application services themselves.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,47 @@ services:
       - loki-data:/loki
     restart: unless-stopped
 
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    command: ["redis-server", "--appendonly", "yes"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    volumes:
+      - redis-data:/data
+    restart: unless-stopped
+
+  hubot:
+    image: ghcr.io/flmesh/hubot:latest
+    container_name: hubot
+    env_file:
+      - .env
+    environment:
+      HUBOT_NAME: ${HUBOT_NAME:-hubot}
+      HUBOT_LOG_LEVEL: ${HUBOT_LOG_LEVEL:-info}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      LOKI_URL: ${LOKI_URL:-http://loki:3100}
+      LOKI_USERNAME: ${LOKI_USERNAME:-}
+      LOKI_PASSWORD: ${LOKI_PASSWORD:-}
+      NODE_LOGS_CACHE_TTL_SECONDS: ${NODE_LOGS_CACHE_TTL_SECONDS:-30}
+    init: true
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "8080"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    depends_on:
+      loki:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
   alloy:
     image: grafana/alloy:v1.15.0
     container_name: alloy
@@ -72,3 +113,4 @@ services:
 volumes:
   loki-data:
   grafana-data:
+  redis-data:


### PR DESCRIPTION
Integrate Redis for Hubot's brain persistence and caching, and colocate Hubot with Loki for log access. Update the Docker Compose setup to include health checks and environment configurations for both services. Provide necessary instructions for running the full stack.