### PR TITLE
Update Discord PR notification image URL and specify Hubot version in Docker Compose

### DIFF
--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -133,7 +133,7 @@ jobs:
                           {"name": "Commits", "value": pr_commits, "inline": True},
                       ],
                       "image": {
-                        "url": f"https://opengraph.githubassets.com/{pr_head_sha}/{repo}"
+                        "url": f"https://opengraph.areyoumeshingwith.us/{pr_head_sha}/{repo}"
                       },
                       "footer": {"text": "GitHub Pull Request Notification"}
                   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,8 @@ services:
     restart: unless-stopped
 
   hubot:
-    image: ghcr.io/flmesh/hubot:1
+    image: ghcr.io/flmesh/hubot:${HUBOT_IMAGE_TAG:-1}
+    pull_policy: always
     container_name: hubot
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     restart: unless-stopped
 
   hubot:
-    image: ghcr.io/flmesh/hubot:latest
+    image: ghcr.io/flmesh/hubot:1
     container_name: hubot
     env_file:
       - .env


### PR DESCRIPTION
Change the Discord PR notification image URL to a new domain and set a specific version for the Hubot Docker image.