### PR TITLE
Add MongoDB configuration to Hubot service in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,17 @@ services:
       LOKI_USERNAME: ${LOKI_USERNAME:-}
       LOKI_PASSWORD: ${LOKI_PASSWORD:-}
       NODE_LOGS_CACHE_TTL_SECONDS: ${NODE_LOGS_CACHE_TTL_SECONDS:-30}
+      MONGO_HOST: ${MONGO_HOST:-host.docker.internal}
+      MONGO_PORT: ${MONGO_PORT:-27017}
+      MONGO_USERNAME: ${MONGO_USERNAME:-}
+      MONGO_PASSWORD: ${MONGO_PASSWORD:-}
+      MONGO_AUTH_SOURCE: ${MONGO_AUTH_SOURCE:-mqtt}
+      MONGO_URL: ${MONGO_URL:-}
+      MONGO_DB_NAME: ${MONGO_DB_NAME:-mqtt}
+      MQTT_ADMIN_ROLE_IDS: ${MQTT_ADMIN_ROLE_IDS:-}
+      MQTT_ADMIN_ROLE_NAMES: ${MQTT_ADMIN_ROLE_NAMES:-}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     init: true
     healthcheck:
       test: ["CMD", "nc", "-z", "127.0.0.1", "8080"]


### PR DESCRIPTION
Introduce MongoDB environment variables to the Hubot service configuration in docker-compose for improved database connectivity.