### PR TITLE
Add Watchtower service and enable labels for Redis, Hubot, and Grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ This stack is intended to monitor:
 
 - the Florida Mesh EMQX broker serving `mqtt.areyoumeshingwith.us`
 - the associated Floodgate services that support that MQTT deployment
+- the MongoDB service used by EMQX for MQTT authentication and authorization
 
 The included dashboards and alert rules are tuned around that environment, especially:
 
 - MQTT broker authentication and authorization failures
 - unexpected denials on Florida topic paths under `msh/US/FL/#`
 - Floodgate service availability, stats emissions, and error lines
+- MongoDB availability, error logs, authentication failures, and EMQX MongoDB driver crashes
 
 Hubot is colocated with Loki so the bot can query the same log store without depending on the EMQX deployment host.
 
@@ -55,6 +57,7 @@ Hubot is colocated with Loki so the bot can query the same log store without dep
 
 - `EMQX Observability` (`emqx-observability`)
 - `Floodgate Observability` (`floodgate-observability`)
+- `MongoDB Observability` (`mongodb-observability`)
 
 ### Alert Groups
 
@@ -70,6 +73,11 @@ Hubot is colocated with Loki so the bot can query the same log store without dep
   - Floodgate no stats lines received
   - Floodgate error lines detected
   - Floodgate stats reported errors
+- `mongodb-observability`
+  - MongoDB no logs received
+  - MongoDB error or fatal lines detected
+  - MongoDB authentication failures detected
+  - EMQX MongoDB driver crashes detected
 
 ## Prerequisites
 
@@ -154,6 +162,7 @@ Additional parsing is applied selectively:
 
 - EMQX logs: extracts `level`, `tag`, and `action`
 - Floodgate logs: extracts `level`, `logger`, `event`, and structured timestamps
+- MongoDB logs: extracts `level` and `component` from MongoDB JSON logs
 
 The Alloy config deliberately keeps labels low-cardinality and leaves most structured fields in the log body for query-time parsing in Loki.
 

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -56,6 +56,28 @@ loki.process "docker_logs" {
     }
   }
 
+
+
+  // MongoDB logs are JSON. Extract only low-cardinality labels and leave
+  // attributes in the body for query-time inspection.
+  stage.match {
+    selector = "{compose_service=\"mongodb\"}"
+
+    stage.json {
+      expressions = {
+        level     = "s",
+        component = "c",
+      }
+    }
+
+    stage.labels {
+      values = {
+        level     = "",
+        component = "",
+      }
+    }
+  }
+
   // Floodgate logs use structured JSON format (python-json-logger) from v0.2.1+.
   // Extract labels from JSON fields and keep the full body for query-time | json parsing.
   stage.match {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
   redis:
     image: redis:8-alpine
     container_name: redis
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     command: ["redis-server", "--appendonly", "yes"]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -38,6 +40,8 @@ services:
     image: ghcr.io/flmesh/hubot:${HUBOT_IMAGE_TAG:-1}
     pull_policy: always
     container_name: hubot
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     env_file:
       - .env
     environment:
@@ -103,6 +107,8 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     env_file:
       - .env
     ports:
@@ -121,6 +127,21 @@ services:
       loki:
         condition: service_healthy
     restart: unless-stopped
+
+  watchtower:
+    image: containrrr/watchtower:latest
+    container_name: watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      WATCHTOWER_LABEL_ENABLE: true
+      WATCHTOWER_CLEANUP: true
+      WATCHTOWER_SCHEDULE: "@hourly"
+      WATCHTOWER_INCLUDE_RESTARTING: true
+      TZ: America/New_York
 
 volumes:
   loki-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,8 +59,9 @@ services:
       MONGO_AUTH_SOURCE: ${MONGO_AUTH_SOURCE:-mqtt}
       MONGO_URL: ${MONGO_URL:-}
       MONGO_DB_NAME: ${MONGO_DB_NAME:-mqtt}
+      HUBOT_DISCORD_PERMISSION_GUILD_ID: ${HUBOT_DISCORD_PERMISSION_GUILD_ID:-}
+      MQTT_ADMIN_GUILD_ID: ${MQTT_ADMIN_GUILD_ID:-}
       MQTT_ADMIN_ROLE_IDS: ${MQTT_ADMIN_ROLE_IDS:-}
-      MQTT_ADMIN_ROLE_NAMES: ${MQTT_ADMIN_ROLE_NAMES:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     init: true
@@ -137,6 +138,7 @@ services:
     env_file:
       - .env
     environment:
+      DOCKER_API_VERSION: "1.40"
       WATCHTOWER_LABEL_ENABLE: true
       WATCHTOWER_CLEANUP: true
       WATCHTOWER_SCHEDULE: "@hourly"

--- a/grafana/dashboards/mongodb-observability-dashboard.json
+++ b/grafana/dashboards/mongodb-observability-dashboard.json
@@ -1,0 +1,418 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({compose_service=\"mongodb\"}[10m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "MongoDB logs in last 10m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({compose_service=\"mongodb\", level=~\"E|F\"}[5m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "MongoDB errors/fatals in last 5m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({compose_service=\"mongodb\", component=\"ACCESS\"} | json | msg=\"Authentication failed\" [5m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "MongoDB auth failures in last 5m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({compose_service=\"emqx\", level=\"error\"} |~ \"mc_monitor|mongodb/src/mongoc|emqx_authn_mongodb|emqx_authz_mongodb\" [15m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "EMQX MongoDB driver crashes in last 15m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum by (level) (count_over_time({compose_service=\"mongodb\"}[5m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "MongoDB log volume by level",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 6,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum by (msg) (count_over_time({compose_service=\"mongodb\", component=\"ACCESS\"} | json | msg=~\"Successfully authenticated|Authentication failed|Connection not authenticating\" [5m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "MongoDB access events",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum by (msg) (count_over_time({compose_service=\"mongodb\", component=\"NETWORK\"} | json | msg=~\"Connection accepted|Connection ended\" [5m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "MongoDB network connection churn",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 8,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum by (component) (count_over_time({compose_service=\"mongodb\", level=~\"W|E|F\"}[15m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "MongoDB components with warnings/errors",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 9,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{compose_service=\"mongodb\", level=~\"W|E|F\"} | json",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Recent MongoDB warnings/errors",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 10,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{compose_service=\"emqx\", level=\"error\"} |~ \"mc_monitor|mongodb/src/mongoc|emqx_authn_mongodb|emqx_authz_mongodb\" | json",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Recent EMQX MongoDB-related errors",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "mongodb",
+    "loki",
+    "emqx"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MongoDB Observability",
+  "uid": "mongodb-observability",
+  "version": 1,
+  "weekStart": ""
+}

--- a/grafana/provisioning/alerting/alert-rules.yaml
+++ b/grafana/provisioning/alerting/alert-rules.yaml
@@ -368,3 +368,146 @@ groups:
       service: floodgate
       severity: critical
     isPaused: false
+
+- orgId: 1
+  name: mongodb-observability
+  folder: EMQX
+  interval: 1m
+  rules:
+  - uid: mongodb-no-logs
+    title: MongoDB no logs received
+    condition: A
+    data:
+    - refId: A
+      queryType: instant
+      relativeTimeRange:
+        from: 1200
+        to: 0
+      datasourceUid: loki
+      model:
+        datasource:
+          type: loki
+          uid: loki
+        editorMode: code
+        expr: absent_over_time({compose_service="mongodb"}[10m])
+        hide: false
+        instant: true
+        intervalMs: 1000
+        maxDataPoints: 43200
+        queryType: instant
+        refId: A
+    dashboardUid: mongodb-observability
+    panelId: 1
+    noDataState: OK
+    execErrState: Error
+    for: 10m
+    annotations:
+      summary: No MongoDB logs seen for 10 minutes.
+      description: No logs from the mongodb compose_service were ingested for the last 10 minutes. This can indicate MongoDB downtime, Docker logging issues, or Alloy/Loki ingestion problems.
+    labels:
+      service: mongodb
+      severity: critical
+    isPaused: false
+  - uid: mongodb-error-lines
+    title: MongoDB error or fatal lines detected
+    condition: A
+    data:
+    - refId: A
+      queryType: instant
+      relativeTimeRange:
+        from: 600
+        to: 0
+      datasourceUid: loki
+      model:
+        datasource:
+          type: loki
+          uid: loki
+        editorMode: code
+        expr: sum(count_over_time({compose_service="mongodb", level=~"E|F"}[5m])) > 0
+        hide: false
+        instant: true
+        intervalMs: 1000
+        maxDataPoints: 43200
+        queryType: instant
+        refId: A
+    dashboardUid: mongodb-observability
+    panelId: 2
+    noDataState: OK
+    execErrState: Error
+    for: 2m
+    annotations:
+      summary: MongoDB emitted error or fatal logs.
+      description: One or more MongoDB E/F severity log entries were seen in the last 5 minutes.
+    labels:
+      service: mongodb
+      severity: critical
+    isPaused: false
+  - uid: mongodb-auth-failures
+    title: MongoDB authentication failures detected
+    condition: A
+    data:
+    - refId: A
+      queryType: instant
+      relativeTimeRange:
+        from: 600
+        to: 0
+      datasourceUid: loki
+      model:
+        datasource:
+          type: loki
+          uid: loki
+        editorMode: code
+        expr: sum(count_over_time({compose_service="mongodb", component="ACCESS"} | json | msg="Authentication failed" [5m])) > 0
+        hide: false
+        instant: true
+        intervalMs: 1000
+        maxDataPoints: 43200
+        queryType: instant
+        refId: A
+    dashboardUid: mongodb-observability
+    panelId: 3
+    noDataState: OK
+    execErrState: Error
+    for: 2m
+    annotations:
+      summary: MongoDB authentication failures detected.
+      description: MongoDB logged one or more authentication failures in the last 5 minutes. This can break EMQX authn/authz if the failing user is the broker user.
+    labels:
+      service: mongodb
+      severity: critical
+    isPaused: false
+  - uid: emqx-mongodb-driver-crashes
+    title: EMQX MongoDB driver crashes detected
+    condition: A
+    data:
+    - refId: A
+      queryType: instant
+      relativeTimeRange:
+        from: 1200
+        to: 0
+      datasourceUid: loki
+      model:
+        datasource:
+          type: loki
+          uid: loki
+        editorMode: code
+        expr: sum(count_over_time({compose_service="emqx", level="error"} |~ "mc_monitor|mongodb/src/mongoc|emqx_authn_mongodb|emqx_authz_mongodb" [15m])) > 0
+        hide: false
+        instant: true
+        intervalMs: 1000
+        maxDataPoints: 43200
+        queryType: instant
+        refId: A
+    dashboardUid: mongodb-observability
+    panelId: 4
+    noDataState: OK
+    execErrState: Error
+    for: 2m
+    annotations:
+      summary: EMQX logged MongoDB driver errors.
+      description: EMQX emitted MongoDB driver/authn/authz related error logs, including possible mc_monitor crashes. Check MongoDB availability and auth latency.
+    labels:
+      service: emqx
+      dependency: mongodb
+      severity: critical
+    isPaused: false


### PR DESCRIPTION
Introduce a Watchtower service for automatic container updates and add labels to Redis, Hubot, and Grafana to enable Watchtower functionality.